### PR TITLE
fix/duplicate signout event tracked removal

### DIFF
--- a/src/components/layouts/HeaderProfileMenuDesktop.tsx
+++ b/src/components/layouts/HeaderProfileMenuDesktop.tsx
@@ -126,7 +126,6 @@ export const HeaderProfileMenuDesktop = ({ ...props }: IButton) => {
                     option: 'Sign Out',
                   }
                 )
-                trackClicked(ClickEvent.LogoutClicked)
                 signOut()
               }}
             >

--- a/src/components/layouts/HeaderProfileMenuMobile.tsx
+++ b/src/components/layouts/HeaderProfileMenuMobile.tsx
@@ -115,7 +115,6 @@ export const HeaderProfileMenuMobile = ({ ...props }: IButton) => {
               colorScheme={'transparent'}
               justifyContent={'start'}
               onClick={() => {
-                trackClicked(ClickEvent.LogoutClicked)
                 signOut()
               }}
             >

--- a/src/services/Amplitude.tsx
+++ b/src/services/Amplitude.tsx
@@ -157,7 +157,6 @@ export enum ClickEvent {
   ShareClicked = 'Share Clicked',
   OpenMarketClicked = 'Open Market Clicked',
   HeaderOptionClicked = 'Header Option Clicked',
-  LogoutClicked = 'Logout Clicked',
   OpenCreatorProfileClicked = 'Open Creator Profile Clicked',
   ProfileBurgerMenuClicked = 'Profile Burger Menu Clicked',
   TradeClicked = 'Trade Clicked',


### PR DESCRIPTION
[LL-35](https://www.notion.so/limitlesslabs/Removal-of-ClickEvent-LogoutClicked-duplicate-on-sign-out-event-tracked-f39b7cf51d5e443fa2ee717bd93ece77)

- chore: removed LogoutClicked member from ClickEvent enum
- chore: removal of trackClicked for removed ClickEvent.LogoutClicked
