### PR TITLE
Increase feed page query limit to 15

### DIFF
--- a/src/hooks/use-feed.ts
+++ b/src/hooks/use-feed.ts
@@ -17,7 +17,7 @@ export function useFeed() {
       const response: AxiosResponse<FeedResponse> = await client.get('/feed', {
         params: {
           page: pageParam,
-          limit: 10,
+          limit: 15,
         },
       })
       // const marketsWithStatusUpdate = response.data.data.filter((market) =>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Increased the number of items fetched per page in the feed from 10 to 15, providing users with more content in a single load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->