### PR TITLE
hide 0 spread

### DIFF
--- a/src/app/(markets)/markets/[address]/components/clob/orderbook-table-large.tsx
+++ b/src/app/(markets)/markets/[address]/components/clob/orderbook-table-large.tsx
@@ -406,11 +406,13 @@ export default function OrderbookTableLarge({
               </Text>
             )}
           </Box>
-          <Box flex={1}>
-            <Text {...paragraphRegular} color='grey.500'>
-              Spread {spread}¢
-            </Text>
-          </Box>
+          {!!Number(spread) ? (
+            <Box flex={1}>
+              <Text {...paragraphRegular} color='grey.500'>
+                Spread {spread}¢
+              </Text>
+            </Box>
+          ) : null}
         </HStack>
       )}
       {!orderbook || orderBookLoading ? (

--- a/src/app/(markets)/markets/[address]/components/clob/orderbook-table-large.tsx
+++ b/src/app/(markets)/markets/[address]/components/clob/orderbook-table-large.tsx
@@ -406,7 +406,7 @@ export default function OrderbookTableLarge({
               </Text>
             )}
           </Box>
-          {!!Number(spread) ? (
+          {Boolean(Number(spread)) ? (
             <Box flex={1}>
               <Text {...paragraphRegular} color='grey.500'>
                 Spread {spread}¢

--- a/src/app/(markets)/markets/[address]/components/clob/orderbook-table-small.tsx
+++ b/src/app/(markets)/markets/[address]/components/clob/orderbook-table-small.tsx
@@ -388,11 +388,13 @@ export default function OrderBookTableSmall({
               </Text>
             )}
           </Box>
-          <Box flex={1}>
-            <Text {...paragraphRegular} color='grey.500'>
-              Spread {spread}¢
-            </Text>
-          </Box>
+          {!!Number(spread) ? (
+            <Box flex={1}>
+              <Text {...paragraphRegular} color='grey.500'>
+                Spread {spread}¢
+              </Text>
+            </Box>
+          ) : null}
         </HStack>
       )}
       <Box position='relative'>

--- a/src/app/(markets)/markets/[address]/components/clob/orderbook-table-small.tsx
+++ b/src/app/(markets)/markets/[address]/components/clob/orderbook-table-small.tsx
@@ -388,7 +388,7 @@ export default function OrderBookTableSmall({
               </Text>
             )}
           </Box>
-          {!!Number(spread) ? (
+          {Boolean(Number(spread)) ? (
             <Box flex={1}>
               <Text {...paragraphRegular} color='grey.500'>
                 Spread {spread}¢


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the order book display to show the spread indicator only when a meaningful value exists, reducing unnecessary clutter.
- **Refactor**
  - Simplified the rendering logic for the spread indicator to respond dynamically based on the actual data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->