### PR TITLE
fixed decimals for asks in orderbook

### DIFF
--- a/src/app/(markets)/markets/[address]/components/clob/orderbook-table-large.tsx
+++ b/src/app/(markets)/markets/[address]/components/clob/orderbook-table-large.tsx
@@ -364,7 +364,7 @@ export default function OrderbookTableLarge({
                   </HStack>
                   <HStack w='136px' h='full' justifyContent='flex-end' pr='8px'>
                     <Text {...paragraphRegular}>
-                      {NumberUtil.toFixed(
+                      {NumberUtil.convertWithDenomination(
                         formatUnits(BigInt(item.size), market?.collateralToken.decimals || 6),
                         2
                       )}
@@ -481,7 +481,7 @@ export default function OrderbookTableLarge({
                   </HStack>
                   <HStack w='136px' h='full' justifyContent='flex-end' pr='8px'>
                     <Text {...paragraphRegular}>
-                      {NumberUtil.toFixed(
+                      {NumberUtil.convertWithDenomination(
                         formatUnits(BigInt(item.size), market?.collateralToken.decimals || 6),
                         2
                       )}

--- a/src/app/(markets)/markets/[address]/components/clob/orderbook.tsx
+++ b/src/app/(markets)/markets/[address]/components/clob/orderbook.tsx
@@ -122,7 +122,7 @@ export default function Orderbook({ variant }: OrderBookProps) {
           .map((bid) => {
             return {
               ...bid,
-              price: +new BigNumber(1).minus(new BigNumber(bid.price)).toFixed(2),
+              price: +new BigNumber(1).minus(new BigNumber(bid.price)),
             }
           })
           .sort((a, b) => b.price - a.price)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated the bid price calculation in the order book to retain full precision, ensuring bid prices are represented more accurately.
	- Modified the display formatting of order book item sizes to include contextual information, enhancing clarity for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->