### PR TITLE
fixed spindl on low envs

### DIFF
--- a/src/providers/Spindl.tsx
+++ b/src/providers/Spindl.tsx
@@ -5,7 +5,11 @@ import { useEffect } from 'react'
 
 export const SpindlProvider = () => {
   useEffect(() => {
-    if (typeof window !== 'undefined' && process.env.NEXT_PUBLIC_SPINDL_SDK_KEY !== 'development') {
+    if (
+      typeof window !== 'undefined' &&
+      process.env.NEXT_PUBLIC_SPINDL_SDK_KEY &&
+      window.location.hostname === 'limitless.exchange'
+    ) {
       spindl.configure({
         sdkKey: process.env.NEXT_PUBLIC_SPINDL_SDK_KEY ?? '',
         host: `${window.location.origin}/ingest`,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the initialization routine so that the service activates only when a valid configuration key is present and the application is accessed from a specific domain. Users accessing the application outside this domain will not trigger the service. This change optimizes behavior strictly within its designated environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->